### PR TITLE
Python: Use new catch-api hostname.

### DIFF
--- a/python/catch-demo.py
+++ b/python/catch-demo.py
@@ -229,8 +229,8 @@ def format_data(data, format):
 
 # command-line interface
 parser = argparse.ArgumentParser()
-parser.add_argument('--base', default='https://catch.astro.umd.edu/api',
-                    help='base URL for query, e.g., https://host/location')
+parser.add_argument('--base', default='https://catch-api.astro.umd.edu',
+                    help='base URL for query, e.g., https://catch-api.astro.umd.edu')
 
 subparsers = parser.add_subparsers(title='API routes')
 

--- a/python/catch-minimal.py
+++ b/python/catch-minimal.py
@@ -29,7 +29,7 @@ params = {
     "cached": "false"
 }
 
-base_url = "https://catch.astro.umd.edu/api"
+base_url = "https://catch-api.astro.umd.edu"
 
 # API route for searches is .../catch
 res = requests.get(base_url + "/catch", params=params)


### PR DESCRIPTION
Use catch-api.astro.umd.edu in python scripts.